### PR TITLE
Fix androidtv vs android_tv script name discrepency

### DIFF
--- a/scripts/androidtv_press_buttons/README.md
+++ b/scripts/androidtv_press_buttons/README.md
@@ -46,7 +46,7 @@ This is my solution: fast, simple, and easy to use.
 youtube_report_ads:
   alias: Report Youtube ads
   sequence:
-    - service: script.android_tv_press_buttons
+    - service: script.androidtv_press_buttons
       data:
         entity_id: media_player.android_tv_living_room
         method: sendevent

--- a/scripts/androidtv_press_buttons/script.yaml
+++ b/scripts/androidtv_press_buttons/script.yaml
@@ -1,4 +1,4 @@
-android_tv_press_buttons:
+androidtv_press_buttons:
   alias: Send button commands to Android TV
   variables:
     # default: use `input keyevent` command, slow but can be used on any Android TVs.

--- a/scripts/androidtv_press_buttons/script.yaml
+++ b/scripts/androidtv_press_buttons/script.yaml
@@ -1,4 +1,4 @@
-androidtv_press_buttons:
+android_tv_press_buttons:
   alias: Send button commands to Android TV
   variables:
     # default: use `input keyevent` command, slow but can be used on any Android TVs.


### PR DESCRIPTION
Examples expect `script.android_tv_press_buttons`, not `script.androidtv_press_buttons`